### PR TITLE
Fix trailing slash in folder name

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -123,6 +123,7 @@ def get_latest_version(versions):
 
 
 def upload_s3_file(bucket_name, folder, file_name, data, content_type='text/plain'):
+    folder = folder.rstrip('/')
     key = '{}/{}'.format(folder, file_name)
     return s3.Object(bucket_name, key).put(Body=data, ContentType=content_type)
 


### PR DESCRIPTION
`maven-metadata.xml` hasn't been updated since #1. @autrilla found this is because of a trailing slash:

```
Uploaded new file maven-default-s3-bucket-1svmqy68t6xd4/maven2/org/mozilla/geckoview/geckoview-nightly-armeabi-v7a//maven-metadata.xml to S3. Result: {'ResponseMetadata': {'RequestId': 'C4BC805255CED5E9', 'HostId': '9tfMd1lCuGqLqEZHmKWM6FiLLyUSNx9YKe2R3gLOl2EXi6sQDd5HhN5uuZe4YLH6wvRQr0uo82I=', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amz-id-2': '9tfMd1lCuGqLqEZHmKWM6FiLLyUSNx9YKe2R3gLOl2EXi6sQDd5HhN5uuZe4YLH6wvRQr0uo82I=', 'x-amz-request-id': 'C4BC805255CED5E9', 'date': 'Mon, 08 Oct 2018 09:33:37 GMT', 'x-amz-version-id': 'w9ioGQC2J.z6Yd9cp32cB3VPZipt8Qjp', 'etag': '"b5303d6ae60e83772ce8a168c73f2a06"', 'content-length': '0', 'server': 'AmazonS3'}, 'RetryAttempts': 0}, 'ETag': '"b5303d6ae60e83772ce8a168c73f2a06"', 'VersionId': 'w9ioGQC2J.z6Yd9cp32cB3VPZipt8Qjp'}
```

The following fix has already been deployed in staging and prod by Adrian.